### PR TITLE
Do not delete dynamic slash commands

### DIFF
--- a/CCSODiscordBot/Services/InteractionHandlingService.cs
+++ b/CCSODiscordBot/Services/InteractionHandlingService.cs
@@ -47,7 +47,7 @@ namespace CCSODiscordBot.Services
 #else
             // Register globally. This is cached by Discord and changes may take a bit.
             Console.WriteLine("Commands set globally.");
-            await _service.RegisterCommandsGloballyAsync();
+            await _service.RegisterCommandsGloballyAsync(false);
 #endif
         }
 


### PR DESCRIPTION
Dynamic slash commands were being deleted. Fixed by telling the bot to not delete "missing" slash commands.